### PR TITLE
chore : Add jpa setting

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -4,9 +4,14 @@ spring:
       enabled: true
       path: /h2
 
-    datasource:
-      url: jdbc:h2:mem:bookjeok;DB_CLOSE_DELAY=-1
-      driver-class-name: org.h2.Driver
-      username: sa
-      password:
+  datasource:
+    url: jdbc:h2:mem:bookjeok;DB_CLOSE_DELAY=-1
+    driver-class-name: org.h2.Driver
+    username: sa
+    password:
 
+  jpa:
+    hibernate:
+      ddl-auto: update
+    database: h2
+    show-sql: true


### PR DESCRIPTION
## 개요
- application.yml의 설정 추가

## 작업 사항
- datasource의 위치 문제 수정
- h2에 테이블이 자동으로 생성되게 jpa 관련 옵션 추가

## 변경 로직
spring:
  h2:
    console:
      enabled: true
      path: /h2

  datasource:
    url: jdbc:h2:mem:bookjeok;DB_CLOSE_DELAY=-1
    driver-class-name: org.h2.Driver
    username: sa
    password:

  jpa:
    hibernate:
      ddl-auto: update
    database: h2
    show-sql: true

![image](https://user-images.githubusercontent.com/103232540/204455965-b4634abb-d18b-4d6a-994f-8ae3bad4c56e.png)

